### PR TITLE
Allow callers to inspect alert records from hello parsing

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -1,0 +1,101 @@
+package tlsutil
+
+import "strconv"
+
+// Alert represents a TLS alert, sent by the peer.
+// See https://datatracker.ietf.org/doc/html/rfc5246#section-7.2
+type Alert uint8
+
+// Possible Alerts. See https://datatracker.ietf.org/doc/html/rfc5246#section-7.2
+const (
+	AlertCloseNotify                  Alert = 0
+	AlertUnexpectedMessage            Alert = 10
+	AlertBadRecordMAC                 Alert = 20
+	AlertDecryptionFailed             Alert = 21
+	AlertRecordOverflow               Alert = 22
+	AlertDecompressionFailure         Alert = 30
+	AlertHandshakeFailure             Alert = 40
+	AlertBadCertificate               Alert = 42
+	AlertUnsupportedCertificate       Alert = 43
+	AlertCertificateRevoked           Alert = 44
+	AlertCertificateExpired           Alert = 45
+	AlertCertificateUnknown           Alert = 46
+	AlertIllegalParameter             Alert = 47
+	AlertUnknownCA                    Alert = 48
+	AlertAccessDenied                 Alert = 49
+	AlertDecodeError                  Alert = 50
+	AlertDecryptError                 Alert = 51
+	AlertExportRestriction            Alert = 60
+	AlertProtocolVersion              Alert = 70
+	AlertInsufficientSecurity         Alert = 71
+	AlertInternalError                Alert = 80
+	AlertInappropriateFallback        Alert = 86
+	AlertUserCanceled                 Alert = 90
+	AlertNoRenegotiation              Alert = 100
+	AlertMissingExtension             Alert = 109
+	AlertUnsupportedExtension         Alert = 110
+	AlertCertificateUnobtainable      Alert = 111
+	AlertUnrecognizedName             Alert = 112
+	AlertBadCertificateStatusResponse Alert = 113
+	AlertBadCertificateHashValue      Alert = 114
+	AlertUnknownPSKIdentity           Alert = 115
+	AlertCertificateRequired          Alert = 116
+	AlertNoApplicationProtocol        Alert = 120
+)
+
+var alertText = map[Alert]string{
+	AlertCloseNotify:                  "close notify",
+	AlertUnexpectedMessage:            "unexpected message",
+	AlertBadRecordMAC:                 "bad record MAC",
+	AlertDecryptionFailed:             "decryption failed",
+	AlertRecordOverflow:               "record overflow",
+	AlertDecompressionFailure:         "decompression failure",
+	AlertHandshakeFailure:             "handshake failure",
+	AlertBadCertificate:               "bad certificate",
+	AlertUnsupportedCertificate:       "unsupported certificate",
+	AlertCertificateRevoked:           "revoked certificate",
+	AlertCertificateExpired:           "expired certificate",
+	AlertCertificateUnknown:           "unknown certificate",
+	AlertIllegalParameter:             "illegal parameter",
+	AlertUnknownCA:                    "unknown certificate authority",
+	AlertAccessDenied:                 "access denied",
+	AlertDecodeError:                  "error decoding message",
+	AlertDecryptError:                 "error decrypting message",
+	AlertExportRestriction:            "export restriction",
+	AlertProtocolVersion:              "protocol version not supported",
+	AlertInsufficientSecurity:         "insufficient security level",
+	AlertInternalError:                "internal error",
+	AlertInappropriateFallback:        "inappropriate fallback",
+	AlertUserCanceled:                 "user canceled",
+	AlertNoRenegotiation:              "no renegotiation",
+	AlertMissingExtension:             "missing extension",
+	AlertUnsupportedExtension:         "unsupported extension",
+	AlertCertificateUnobtainable:      "certificate unobtainable",
+	AlertUnrecognizedName:             "unrecognized name",
+	AlertBadCertificateStatusResponse: "bad certificate status response",
+	AlertBadCertificateHashValue:      "bad certificate hash value",
+	AlertUnknownPSKIdentity:           "unknown PSK identity",
+	AlertCertificateRequired:          "certificate required",
+	AlertNoApplicationProtocol:        "no application protocol",
+}
+
+func (e Alert) String() string {
+	s, ok := alertText[e]
+	if ok {
+		return s
+	}
+	return "alert(" + strconv.Itoa(int(e)) + ")"
+}
+
+func (e Alert) Error() string {
+	return e.String()
+}
+
+// ErrorUnexpectedAlert is returned in some cases when an alert record is encountered unexpectedly.
+type ErrorUnexpectedAlert struct {
+	Alert Alert
+}
+
+func (e ErrorUnexpectedAlert) Error() string {
+	return "received unexpected alert record"
+}

--- a/hello_test.go
+++ b/hello_test.go
@@ -19,7 +19,7 @@ func TestClientHelloEdgeCases(t *testing.T) {
 			0x03, 0x03, // version: TLS 1.2
 			0x00, 0x00, // payload length: 0 bytes
 			// == Handshake header ==
-			0x01,             // handshake message type: client hello
+			0x01,             // handshake message type: ClientHello
 			0x00, 0x00, 0x00, // handshake payload length: 0 bytes
 		},
 		// record payload too small (handshake payload should be >= 4 bytes)
@@ -29,7 +29,7 @@ func TestClientHelloEdgeCases(t *testing.T) {
 			0x03, 0x03, // version: TLS 1.2
 			0x00, 0x03, // payload length: 3 bytes
 			// == Handshake header ==
-			0x01,             // handshake message type: client hello
+			0x01,             // handshake message type: ClientHello
 			0x00, 0x00, 0x00, // handshake payload length: 0 bytes
 		},
 		// payload length disagreement: record length too small
@@ -39,7 +39,7 @@ func TestClientHelloEdgeCases(t *testing.T) {
 			0x03, 0x03, // version: TLS 1.2
 			0x00, 0x04, // payload length: 4 bytes
 			// == Handshake header ==
-			0x01,             // handshake message type: client hello
+			0x01,             // handshake message type: ClientHello
 			0x00, 0x00, 0x02, // handshake payload length: 2 bytes
 			0x03, 0x03, // client version: TLS 1.2
 		},
@@ -50,7 +50,7 @@ func TestClientHelloEdgeCases(t *testing.T) {
 			0x03, 0x03, // version: TLS 1.2
 			0x00, 0x04, // payload length: 4 bytes
 			// == Handshake header ==
-			0x01,             // handshake message type: client hello
+			0x01,             // handshake message type: ClientHello
 			0x00, 0x00, 0x00, // handshake payload length: 0 bytes
 		},
 		// handshake payload too small
@@ -60,7 +60,7 @@ func TestClientHelloEdgeCases(t *testing.T) {
 			0x03, 0x03, // version: TLS 1.2
 			0x00, 0x06, // payload length: 6 bytes
 			// == Handshake header ==
-			0x01,             // handshake message type: client hello
+			0x01,             // handshake message type: ClientHello
 			0x00, 0x00, 0x02, // handshake payload length: 2 bytes
 			0x03, 0x03, // client version: TLS 1.2
 		},


### PR DESCRIPTION
Just going to merge this in.  It doesn't really change anything, just allows callers to do things like:
```
var alertErr ErrorUnexpectedAlert
hello, err := ParseServerHello(b)
if errors.As(err, &alertErr) {
  switch alertErr {
  case AlertHandshakeFailure:
    // do something
  ... blah blah blah ...
  }
}
```